### PR TITLE
chore: rename Readme Shop branding to Markdown Shop

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "Readme Shop Development",
+  "name": "Markdown Shop Development",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:20",
   "features": {
     "ghcr.io/devcontainers/features/git:1": {},

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.git
+.gitignore
+npm-debug.log*

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,10 @@
 # GitHub Copilot Instructions
 
-Use this file as the source of truth for working in the README-SHOP codebase. Prefer the repository contents over external assumptions.
+Use this file as the source of truth for working in the Markdown Shop codebase. Prefer the repository contents over external assumptions.
 
 ## Project Summary
 
-README-SHOP is a modern React 18 + Vite application for building and customizing GitHub README files. The app provides templates, icons, GitHub stats components, a markdown editor with live preview, and export/embed options. Styling is primarily Material UI (MUI) with Emotion, with motion effects via Framer Motion.
+Markdown Shop is a modern React 18 + Vite application for building and customizing GitHub README files. The app provides templates, icons, GitHub stats components, a markdown editor with live preview, and export/embed options. Styling is primarily Material UI (MUI) with Emotion, with motion effects via Framer Motion.
 
 ## Tech Stack
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial README-SHOP application foundation.
+- Initial Markdown Shop application foundation.
 - Icons and badges components, including icon/badge data sources.
 - README templates support with drawer and template expansion.
 - Output enhancements such as auto-populated icons and badges.
@@ -50,4 +50,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Home page and core feature files repeatedly reorganized for clarity.
 - Theme and UI consistency refactors for long-term maintainability.
 
-[Unreleased]: https://github.com/narainkarthikv/readme-shop/compare/1618fbf...HEAD
+[Unreleased]: https://github.com/narainkarthikv/markdown-shop/compare/1618fbf...HEAD

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -24,7 +24,7 @@ Examples of unacceptable behavior:
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders via:
 
-- https://github.com/narainkarthikv/readme-shop/issues/new?template=other_request.md
+- https://github.com/narainkarthikv/markdown-shop/issues/new?template=other_request.md
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to README-SHOP
+# Contributing to Markdown Shop
 
 Thank you for your interest in contributing! 🚀
 

--- a/Contributors.md
+++ b/Contributors.md
@@ -1,6 +1,6 @@
 # Contributors
 
-- [Wisdom Fox](https://github.com/narainkarthikv) **Creator of README-SHOP**
+- [Wisdom Fox](https://github.com/narainkarthikv) **Creator of Markdown Shop**
 
 ## Open Source Contributors
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM nginx:1.27-alpine AS runner
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# README-SHOP
+# Markdown Shop
 
-[![License](https://img.shields.io/github/license/narainkarthikv/readme-shop)](./LICENSE)
-[![Version](https://img.shields.io/github/package-json/v/narainkarthikv/readme-shop)](./package.json)
-[![Last Commit](https://img.shields.io/github/last-commit/narainkarthikv/readme-shop)](https://github.com/narainkarthikv/readme-shop/commits/develop)
-[![GitHub issues](https://img.shields.io/github/issues/narainkarthikv/readme-shop)](https://github.com/narainkarthikv/readme-shop/issues)
-[![GitHub stars](https://img.shields.io/github/stars/narainkarthikv/readme-shop)](https://github.com/narainkarthikv/readme-shop/stargazers)
+[![License](https://img.shields.io/github/license/narainkarthikv/markdown-shop)](./LICENSE)
+[![Version](https://img.shields.io/github/package-json/v/narainkarthikv/markdown-shop)](./package.json)
+[![Last Commit](https://img.shields.io/github/last-commit/narainkarthikv/markdown-shop)](https://github.com/narainkarthikv/markdown-shop/commits/develop)
+[![GitHub issues](https://img.shields.io/github/issues/narainkarthikv/markdown-shop)](https://github.com/narainkarthikv/markdown-shop/issues)
+[![GitHub stars](https://img.shields.io/github/stars/narainkarthikv/markdown-shop)](https://github.com/narainkarthikv/markdown-shop/stargazers)
 
 **Structure your README with confidence. Build clean, ready-to-publish documentation using guided templates and live previews.**
 
-README-SHOP is a React 18 + Vite web app that helps you assemble professional README files using templates, badges, GitHub stats components, and a live markdown editor. The output is sanitized and ready to copy or embed.
+Markdown Shop is a React 18 + Vite web app that helps you assemble professional README files using templates, badges, GitHub stats components, and a live markdown editor. The output is sanitized and ready to copy or embed.
 
 ## ✨ Features
 
@@ -31,8 +31,8 @@ README-SHOP is a React 18 + Vite web app that helps you assemble professional RE
 
 ````bash
 # Clone the repository
-git clone https://github.com/narainkarthikv/readme-shop.git
-cd readme-shop
+git clone https://github.com/narainkarthikv/markdown-shop.git
+cd markdown-shop
 
 # Install dependencies
 npm install
@@ -83,7 +83,7 @@ npm run preview
 ## 📁 Project Structure
 
 ```
-readme-shop/
+markdown-shop/
 ├── public/
 ├── src/
 │   ├── assets/data/       # Templates and icon catalogs
@@ -103,7 +103,7 @@ readme-shop/
 
 ## 🔑 Environment Variables
 
-README-SHOP does not require any environment variables for local development.
+Markdown Shop does not require any environment variables for local development.
 
 ## 🧪 Development
 
@@ -147,8 +147,8 @@ This project is licensed under the **MIT License**. See [LICENSE](./LICENSE) for
 
 ## 🔗 Links
 
-- **Live Demo**: https://readmeshopwf.netlify.app/
-- **Repository**: https://github.com/narainkarthikv/readme-shop
+- **Live Demo**: https://markdownshop.netlify.app/
+- **Repository**: https://github.com/narainkarthikv/markdown-shop
 
 ### Contribution workflow (detailed)
 
@@ -188,13 +188,13 @@ This project is licensed under the **MIT License**. See [LICENSE](./LICENSE) for
 
 ## 👥 Contributors
 
-Thanks to everyone who has helped make README-SHOP awesome! 💪
+Thanks to everyone who has helped make Markdown Shop awesome! 💪
 
-<a href="https://github.com/narainkarthikv/readme-shop/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=narainkarthikv/readme-shop" />
+<a href="https://github.com/narainkarthikv/markdown-shop/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=narainkarthikv/markdown-shop" />
 </a>
 
-See the [Contributors Page](https://github.com/narainkarthikv/readme-shop/blob/main/Contributors.md) for the full list.
+See the [Contributors Page](https://github.com/narainkarthikv/markdown-shop/blob/main/Contributors.md) for the full list.
 
 ### How to Add Yourself
 
@@ -204,12 +204,12 @@ When your PR is merged, add yourself to the `Contributors.md` file following the
 
 ## Support
 
-If you find README-SHOP helpful:
+If you find Markdown Shop helpful:
 
 - ⭐ **Star the repository** on GitHub
-- 🐛 **Report bugs** through [Issues](https://github.com/narainkarthikv/readme-shop/issues)
-- 💡 **Suggest features** in [Discussions](https://github.com/narainkarthikv/readme-shop/discussions)
-- 📢 **Share** README-SHOP with your network
+- 🐛 **Report bugs** through [Issues](https://github.com/narainkarthikv/markdown-shop/issues)
+- 💡 **Suggest features** in [Discussions](https://github.com/narainkarthikv/markdown-shop/discussions)
+- 📢 **Share** Markdown Shop with your network
 - 💬 **Participate** in community discussions
 
 ### Special Thanks
@@ -234,10 +234,11 @@ See the [LICENSE](./LICENSE) file for full details.
 
 ## 🔗 Quick Links
 
-- **Website:** [readme-shop.vercel.app](https://readme-shop.vercel.app/)
-- **GitHub Repository:** [narainkarthikv/readme-shop](https://github.com/narainkarthikv/readme-shop)
-- **Issues:** [Report a bug or request a feature](https://github.com/narainkarthikv/readme-shop/issues)
-- **Discussions:** [Join the community](https://github.com/narainkarthikv/readme-shop/discussions)
+- **Production:** [markdownshop.netlify.app](https://markdownshop.netlify.app/)
+- **Development:** [markdownshop-dev.vercel.app](https://markdownshop-dev.vercel.app/)
+- **GitHub Repository:** [narainkarthikv/markdown-shop](https://github.com/narainkarthikv/markdown-shop)
+- **Issues:** [Report a bug or request a feature](https://github.com/narainkarthikv/markdown-shop/issues)
+- **Discussions:** [Join the community](https://github.com/narainkarthikv/markdown-shop/discussions)
 - **Contributing Guide:** [CONTRIBUTING.md](./CONTRIBUTING.md)
 - **Code of Conduct:** [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
 - **Security Policy:** [SECURITY.md](./SECURITY.md)
@@ -257,7 +258,7 @@ See the [LICENSE](./LICENSE) file for full details.
 
 ## 💡 Final Thoughts
 
-We're building **README-SHOP** as a community-driven tool to help developers create professional, engaging GitHub README files with ease. Your code, ideas, and feedback make it stronger every day.
+We're building **Markdown Shop** as a community-driven tool to help developers create professional, engaging GitHub README files with ease. Your code, ideas, and feedback make it stronger every day.
 
 Whether you're fixing a typo, improving performance, adding a new template, or building amazing features — **every contribution matters!** 🏗️💚
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ If you discover a security issue, please use the preferred channels below:
 
 - GitHub Security Advisories (preferred, if enabled for this repository)
 - If advisories are not available, open an issue with minimal details and mark it as a security concern:
-  https://github.com/narainkarthikv/readme-shop/issues/new?template=other_request.md
+  https://github.com/narainkarthikv/markdown-shop/issues/new?template=other_request.md
 
 Please avoid sharing sensitive details publicly until a fix is released.
 

--- a/index.html
+++ b/index.html
@@ -13,10 +13,10 @@
 
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <!-- Primary Meta Tags -->
-    <title>README Shop - Build polished GitHub READMEs in minutes</title>
+    <title>Markdown Shop - Build polished GitHub READMEs in minutes</title>
     <meta
       name="title"
-      content="README Shop - Build polished GitHub READMEs in minutes" />
+      content="Markdown Shop - Build polished GitHub READMEs in minutes" />
     <meta
       name="description"
       content="Structure your README with confidence. Build clean, ready-to-publish documentation using guided templates and live previews." />
@@ -29,16 +29,16 @@
 
     <!-- Open Graph / Social -->
     <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="README Shop" />
-    <meta property="og:url" content="https://readme-shop.vercel.app" />
+    <meta property="og:site_name" content="Markdown Shop" />
+    <meta property="og:url" content="https://markdownshop-dev.vercel.app" />
     <meta
       property="og:title"
-      content="README Shop - Build polished GitHub READMEs in minutes" />
+      content="Markdown Shop - Build polished GitHub READMEs in minutes" />
     <meta
       property="og:description"
       content="Structure your README with confidence. Build clean, ready-to-publish documentation using guided templates and live previews." />
     <meta property="og:image" content="/og-image.svg" />
-    <meta property="og:image:alt" content="README Shop preview" />
+    <meta property="og:image:alt" content="Markdown Shop preview" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:locale" content="en_US" />
@@ -49,12 +49,12 @@
     <meta name="twitter:creator" content="@narainkarthik" />
     <meta
       name="twitter:title"
-      content="README Shop - Build polished GitHub READMEs in minutes" />
+      content="Markdown Shop - Build polished GitHub READMEs in minutes" />
     <meta
       name="twitter:description"
       content="Structure your README with confidence. Build clean, ready-to-publish documentation using guided templates and live previews." />
     <meta name="twitter:image" content="/og-image.svg" />
-    <meta name="twitter:image:alt" content="README Shop preview" />
+    <meta name="twitter:image:alt" content="Markdown Shop preview" />
 
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -67,14 +67,14 @@
     <meta name="bingbot" content="index, follow" />
 
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://readmeshopwf.netlify.app/" />
+    <link rel="canonical" href="https://markdownshop.netlify.app/" />
 
     <!-- Structured Data (JSON-LD) -->
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
-        "name": "README Shop",
+        "name": "Markdown Shop",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "Web Browser",
         "browserRequirements": "Requires JavaScript. Compatible with Chrome, Firefox, Safari, Edge.",
@@ -100,10 +100,10 @@
         ],
         "softwareHelp": {
           "@type": "WebPage",
-          "url": "https://readme-shop.vercel.app"
+          "url": "https://markdownshop-dev.vercel.app"
         },
-        "screenshot": "https://readme-shop.vercel.app/og-image.svg",
-        "url": "https://readme-shop.vercel.app",
+        "screenshot": "https://markdownshop-dev.vercel.app/og-image.svg",
+        "url": "https://markdownshop-dev.vercel.app",
         "keywords": "README builder, GitHub README, README templates, badges, icons, markdown preview"
       }
     </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "readme-shop",
+  "name": "markdown-shop",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "readme-shop",
+      "name": "markdown-shop",
       "version": "1.0.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "readme-shop",
+  "name": "markdown-shop",
   "private": true,
   "version": "1.0.0",
   "type": "module",

--- a/public/og-image.svg
+++ b/public/og-image.svg
@@ -12,7 +12,7 @@
   <rect width="1200" height="630" fill="url(#bg)" />
   <rect width="1200" height="630" fill="url(#glow)" />
   <rect x="80" y="120" width="1040" height="390" rx="28" fill="#0F172A" stroke="#1E293B" stroke-width="2" />
-  <text x="140" y="250" fill="#E2E8F0" font-family="Sora, Arial, sans-serif" font-size="56" font-weight="700">README Shop</text>
+  <text x="140" y="250" fill="#E2E8F0" font-family="Sora, Arial, sans-serif" font-size="56" font-weight="700">Markdown Shop</text>
   <text x="140" y="315" fill="#94A3B8" font-family="Sora, Arial, sans-serif" font-size="28" font-weight="500">Build polished GitHub READMEs in minutes</text>
   <rect x="140" y="355" width="240" height="54" rx="27" fill="#2563EB" />
   <text x="170" y="390" fill="#F8FAFC" font-family="Sora, Arial, sans-serif" font-size="20" font-weight="600">Start Building</text>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,7 +43,7 @@ const SEO = memo(
     themeColor = '#3B82F6',
   }) => (
     <Helmet>
-      <title>{title || 'README Shop'}</title>
+      <title>{title || 'Markdown Shop'}</title>
       <meta
         name='description'
         content={
@@ -55,13 +55,13 @@ const SEO = memo(
         name='keywords'
         content={
           keywords ||
-          'readme-shop, README generator, markdown, templates, open source, documentation'
+          'markdown shop, README generator, markdown, templates, open source, documentation'
         }
       />
       <meta name='viewport' content='width=device-width, initial-scale=1.0' />
       <meta name='theme-color' content={themeColor} />
       {isHome && (
-        <link rel='canonical' href='https://readmeshopwf.netlify.app/' />
+        <link rel='canonical' href='https://markdownshop.netlify.app/' />
       )}
     </Helmet>
   )

--- a/src/components/CustomDrawer.jsx
+++ b/src/components/CustomDrawer.jsx
@@ -123,7 +123,7 @@ const CustomDrawer = ({ open, onClose, currentPath }) => {
         {/* Footer */}
         <Box sx={{ mt: 'auto', p: 2, textAlign: 'center' }}>
           <Typography variant='caption' color='text.secondary'>
-            README Shop © 2026
+            Markdown Shop © 2026
           </Typography>
         </Box>
       </Box>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -75,7 +75,7 @@ const Footer = React.memo(() => (
         px: { xs: 2, md: 3 },
         py: { xs: 5, md: 7 },
       }}>
-      <Grid container spacing={{ xs: 4, md: 5 }}>
+      <Grid container spacing={{ xs: 3, md: 4 }} justifyContent="space-between">
         <Grid item xs={12} md={4}>
           <Typography
             variant='h6'

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -11,7 +11,7 @@ const footerLinks = [
       { label: 'Components', to: '/components', internal: true },
       {
         label: 'GitHub repo',
-        href: 'https://github.com/narainkarthikv/readme-shop',
+        href: 'https://github.com/narainkarthikv/markdown-shop',
       },
     ],
   },
@@ -20,15 +20,15 @@ const footerLinks = [
     links: [
       {
         label: 'Contributing',
-        href: 'https://github.com/narainkarthikv/readme-shop/blob/develop/CONTRIBUTING.md',
+        href: 'https://github.com/narainkarthikv/markdown-shop/blob/develop/CONTRIBUTING.md',
       },
       {
         label: 'Code of conduct',
-        href: 'https://github.com/narainkarthikv/readme-shop/blob/develop/CODE_OF_CONDUCT.md',
+        href: 'https://github.com/narainkarthikv/markdown-shop/blob/develop/CODE_OF_CONDUCT.md',
       },
       {
         label: 'Issues & roadmap',
-        href: 'https://github.com/narainkarthikv/readme-shop/issues',
+        href: 'https://github.com/narainkarthikv/markdown-shop/issues',
       },
       {
         label: 'Wisdom Fox',
@@ -41,19 +41,19 @@ const footerLinks = [
     links: [
       {
         label: 'MIT License',
-        href: 'https://github.com/narainkarthikv/readme-shop/blob/develop/LICENSE',
+        href: 'https://github.com/narainkarthikv/markdown-shop/blob/develop/LICENSE',
       },
       {
         label: 'Security policy',
-        href: 'https://github.com/narainkarthikv/readme-shop/security/policy',
+        href: 'https://github.com/narainkarthikv/markdown-shop/security/policy',
       },
       {
         label: 'Release notes',
-        href: 'https://github.com/narainkarthikv/readme-shop/releases',
+        href: 'https://github.com/narainkarthikv/markdown-shop/releases',
       },
       {
         label: 'Documentation',
-        href: 'https://github.com/narainkarthikv/readme-shop#readme',
+        href: 'https://github.com/narainkarthikv/markdown-shop#readme',
       },
     ],
   },
@@ -75,12 +75,12 @@ const Footer = React.memo(() => (
         px: { xs: 2, md: 3 },
         py: { xs: 5, md: 7 },
       }}>
-      <Grid container spacing={{ xs: 3, md: 4 }} justifyContent="space-between">
+      <Grid container spacing={{ xs: 3, md: 4 }} justifyContent='space-between'>
         <Grid item xs={12} md={4}>
           <Typography
             variant='h6'
             sx={{ fontWeight: 700, color: 'text.primary' }}>
-            README Shop
+            Markdown Shop
           </Typography>
           <Typography variant='body2' sx={{ mt: 2, color: 'text.secondary' }}>
             A fast README builder for open-source maintainers and makers. Curate
@@ -137,7 +137,7 @@ const Footer = React.memo(() => (
           alignItems={{ sm: 'center' }}
           sx={{ pt: { xs: 3, md: 3.5 } }}>
           <Typography variant='caption'>
-            © 2026 README Shop. Crafted with care for open source.
+            © 2026 Markdown Shop. Crafted with care for open source.
           </Typography>
           <Typography variant='caption'>
             Have feedback? Open an issue or drop a PR.

--- a/src/components/Home/CommunitySection.jsx
+++ b/src/components/Home/CommunitySection.jsx
@@ -49,7 +49,7 @@ const CommunitySection = () => {
               mx: 'auto',
               mb: 3,
             }}>
-            README Shop is built by the Wisdom Fox community. If this project
+            Markdown Shop is built by the Wisdom Fox community. If this project
             helps your work, consider supporting ongoing development and open
             tooling for creators.
           </Typography>
@@ -68,7 +68,7 @@ const CommunitySection = () => {
             <Button
               variant='outlined'
               color='primary'
-              href='https://github.com/narainkarthikv/readme-shop'
+              href='https://github.com/narainkarthikv/markdown-shop'
               target='_blank'
               rel='noreferrer'>
               Star on GitHub

--- a/src/components/Home/HeroSection.jsx
+++ b/src/components/Home/HeroSection.jsx
@@ -184,7 +184,7 @@ const HeroSection = () => {
                   <Typography
                     variant='overline'
                     sx={{ letterSpacing: '0.2em' }}>
-                    README SHOP
+                    MARKDOWN SHOP
                   </Typography>
                   <Typography
                     variant='h4'

--- a/src/components/Home/InfoSection.jsx
+++ b/src/components/Home/InfoSection.jsx
@@ -30,8 +30,8 @@ const InfoSection = () => {
   const theme = useTheme();
 
   return (
-    <Section aria-label='Why README Shop'>
-      <SectionTitle>Why README Shop</SectionTitle>
+    <Section aria-label='Why Markdown Shop'>
+      <SectionTitle>Why Markdown Shop</SectionTitle>
       <Typography
         variant='body1'
         sx={{

--- a/src/components/Home/SupportSection.jsx
+++ b/src/components/Home/SupportSection.jsx
@@ -38,7 +38,7 @@ const SupportSection = () => {
               letterSpacing: '0.32em',
               color: theme.palette.text.secondary,
             }}>
-            README SHOP COMMUNITY
+            MARKDOWN SHOP COMMUNITY
           </Typography>
           <Typography variant='h3' sx={{ fontWeight: 700, mt: 1, mb: 1.5 }}>
             Support open-source README craftsmanship
@@ -51,7 +51,7 @@ const SupportSection = () => {
               mx: 'auto',
               mb: 3,
             }}>
-            README Shop is maintained by the Wisdom Fox community. If this
+            Markdown Shop is maintained by the Wisdom Fox community. If this
             project saves you time, consider supporting the next release and
             sustainable open tooling for creators.
           </Typography>
@@ -71,7 +71,7 @@ const SupportSection = () => {
             <Button
               variant='contained'
               color='primary'
-              href='https://github.com/narainkarthikv/readme-shop'
+              href='https://github.com/narainkarthikv/markdown-shop'
               target='_blank'
               rel='noreferrer'
               sx={{ px: 3.5, borderRadius: 999 }}>
@@ -85,7 +85,7 @@ const SupportSection = () => {
               mt: 2,
               color: theme.palette.text.secondary,
             }}>
-            Donations are optional. README Shop will always be free and open
+            Donations are optional. Markdown Shop will always be free and open
             source.
           </Typography>
         </Box>

--- a/src/components/Home/ThanksSection.jsx
+++ b/src/components/Home/ThanksSection.jsx
@@ -50,9 +50,9 @@ const ThanksSection = () => {
               mb: 3,
               mx: 'auto',
             }}>
-            README Shop stands on the shoulders of incredible open-source work.
-            We are grateful to the projects and communities that make this
-            possible.
+            Markdown Shop stands on the shoulders of incredible open-source
+            work. We are grateful to the projects and communities that make
+            this possible.
           </Typography>
           <Box sx={{ maxWidth: 900, mx: 'auto', textAlign: 'left' }}>
             <Stack spacing={2}>
@@ -123,7 +123,7 @@ const ThanksSection = () => {
               maxWidth: 720,
               mx: 'auto',
             }}>
-            README Shop is maintained by the Wisdom Fox community. If the
+            Markdown Shop is maintained by the Wisdom Fox community. If the
             project saves you time, consider fueling the next release with a
             small pledge or a coffee.
           </Typography>
@@ -160,7 +160,7 @@ const ThanksSection = () => {
               mt: 2,
               color: theme.palette.text.secondary,
             }}>
-            Donations are optional. README Shop will always be free and open
+            Donations are optional. Markdown Shop will always be free and open
             source.
           </Typography>
         </Paper>

--- a/src/components/Home/TrustSection.jsx
+++ b/src/components/Home/TrustSection.jsx
@@ -52,7 +52,7 @@ const TrustSection = () => {
           mx: 'auto',
           mb: 5,
         }}>
-        README Shop respects your work: no lock-in, no noisy marketing, just
+        Markdown Shop respects your work: no lock-in, no noisy marketing, just
         clean documentation that earns confidence.
       </Typography>
 

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -79,7 +79,7 @@ const Navbar = () => {
               opacity: 0.8,
             },
           }}>
-          README SHOP
+          MARKDOWN SHOP
         </Typography>
 
         {/* Right side: Action icons */}

--- a/src/components/SvgBanners.jsx
+++ b/src/components/SvgBanners.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Box, Typography, alpha, useTheme } from '@mui/material';
 import useMarkdownStore from '@/features/markdown/store/markdownStore';
 
-const SVG_BANNER_MARKDOWN = `<a href="https://github.com/narainkarthikv/svg-banners" target="_blank"><img src="https://svg-banners.vercel.app/api?type=luminance&text1=README%20SHOP&width=1000&height=200" alt="SVG Banner" style="width:100%;max-width:600px;border-radius:8px;" /></a>`;
+const SVG_BANNER_MARKDOWN = `<a href="https://github.com/narainkarthikv/svg-banners" target="_blank"><img src="https://svg-banners.vercel.app/api?type=luminance&text1=Markdown%20Shop&width=1000&height=200" alt="SVG Banner" style="width:100%;max-width:600px;border-radius:8px;" /></a>`;
 
 const SvgBanners = React.memo(() => {
   const theme = useTheme();
@@ -74,8 +74,8 @@ const SvgBanners = React.memo(() => {
           rel='noopener noreferrer'
           onClick={(e) => e.preventDefault()}>
           <img
-            src='https://svg-banners.vercel.app/api?type=luminance&text1=README%20SHOP&width=1000&height=200'
-            alt='SVG Banner - README SHOP'
+            src='https://svg-banners.vercel.app/api?type=luminance&text1=Markdown%20Shop&width=1000&height=200'
+            alt='SVG Banner - MARKDOWN SHOP'
             style={{
               width: '100%',
               maxWidth: 500,

--- a/src/components/Templates/TemplateCard.jsx
+++ b/src/components/Templates/TemplateCard.jsx
@@ -14,7 +14,6 @@ import {
   Dialog,
   DialogTitle,
   DialogContent,
-  DialogActions,
   IconButton,
   Divider,
 } from '@mui/material';
@@ -378,10 +377,14 @@ const TemplateCard = ({
         onClose={handlePreviewClose}
         maxWidth='md'
         fullWidth
+        scroll='paper'
         PaperProps={{
           sx: {
             borderRadius: 2,
+            position: 'fixed',
             maxHeight: '85vh',
+            display: 'flex',
+            overflow: 'hidden',
           },
         }}>
         <DialogTitle
@@ -408,20 +411,38 @@ const TemplateCard = ({
               />
             )}
           </Box>
-          <IconButton
-            onClick={handlePreviewClose}
-            size='small'
-            sx={{
-              color: 'text.secondary',
-              '&:hover': { bgcolor: alpha(theme.palette.text.secondary, 0.1) },
-            }}>
-            <CloseIcon />
-          </IconButton>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <ButtonGroup variant='contained' size='small'>
+              <Button
+                onClick={handleCopy}
+                startIcon={copied ? <CheckIcon /> : <ContentCopyIcon />}
+                color={copied ? 'success' : 'primary'}
+                sx={{ borderRadius: '6px 0 0 6px' }}>
+                {copied ? 'Copied' : 'Copy'}
+              </Button>
+              <Button
+                onClick={handleUse}
+                startIcon={<AddIcon />}
+                color='primary'
+                sx={{ borderRadius: '0 6px 6px 0' }}>
+                Use Template
+              </Button>
+            </ButtonGroup>
+            <IconButton
+              onClick={handlePreviewClose}
+              size='small'
+              sx={{
+                color: 'text.secondary',
+                '&:hover': { bgcolor: alpha(theme.palette.text.secondary, 0.1) },
+              }}>
+              <CloseIcon />
+            </IconButton>
+          </Box>
         </DialogTitle>
 
         <Divider />
 
-        <DialogContent sx={{ pt: 3 }}>
+        <DialogContent sx={{ pt: 3, overflowY: 'auto' }}>
           <Typography
             variant='body2'
             color='text.secondary'
@@ -463,33 +484,6 @@ const TemplateCard = ({
           </Paper>
         </DialogContent>
 
-        <Divider />
-
-        <DialogActions sx={{ p: 2.5, gap: 1 }}>
-          <Button
-            onClick={handlePreviewClose}
-            variant='outlined'
-            color='inherit'
-            sx={{ borderRadius: 1.5 }}>
-            Close
-          </Button>
-          <ButtonGroup variant='contained' size='medium'>
-            <Button
-              onClick={handleCopy}
-              startIcon={copied ? <CheckIcon /> : <ContentCopyIcon />}
-              color={copied ? 'success' : 'primary'}
-              sx={{ borderRadius: '6px 0 0 6px' }}>
-              {copied ? 'Copied' : 'Copy'}
-            </Button>
-            <Button
-              onClick={handleUse}
-              startIcon={<AddIcon />}
-              color='primary'
-              sx={{ borderRadius: '0 6px 6px 0' }}>
-              Use Template
-            </Button>
-          </ButtonGroup>
-        </DialogActions>
       </Dialog>
     </>
   );

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -3,7 +3,7 @@ export const STORAGE_KEYS = {
 };
 
 export const GITHUB_URLS = {
-  REPOSITORY: 'https://github.com/narainkarthikv/readme-shop',
+  REPOSITORY: 'https://github.com/narainkarthikv/markdown-shop',
   COMMUNITY: 'https://github.com/narainkarthikv',
 };
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -14,16 +14,16 @@ export const ENV = {
  * Storage Keys
  */
 export const STORAGE_KEYS = {
-  THEME_MODE: 'readme-shop-theme-mode',
-  USER_PREFERENCES: 'readme-shop-preferences',
-  STORE: 'readme-shop-store',
+  THEME_MODE: 'markdown-shop-theme-mode',
+  USER_PREFERENCES: 'markdown-shop-preferences',
+  STORE: 'markdown-shop-store',
 };
 
 /**
  * External URLs
  */
 export const GITHUB_URLS = {
-  REPOSITORY: 'https://github.com/narainkarthikv/readme-shop',
+  REPOSITORY: 'https://github.com/narainkarthikv/markdown-shop',
   COMMUNITY: 'https://github.com/narainkarthikv',
 };
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -42,7 +42,7 @@ export const API_ENDPOINTS = {
 export const THEME_OPTIONS = {
   LIGHT: 'light',
   DARK: 'dark',
-  DEFAULT: 'light',
+  DEFAULT: 'dark',
 };
 
 /**

--- a/src/context/store/useShopStore.jsx
+++ b/src/context/store/useShopStore.jsx
@@ -6,7 +6,7 @@ const initialState = {
   badgeSearchTerm: '',
   selectedBadges: [],
   iconSearchTerm: '',
-  themeMode: 'light',
+  themeMode: 'dark',
   loading: false,
   error: null,
 };

--- a/src/features/github/components/GithubBadges.jsx
+++ b/src/features/github/components/GithubBadges.jsx
@@ -9,8 +9,8 @@ import { getGithubUser } from '../utils/githubUser';
 const buildBadgesMarkdown = (userName) =>
   [
     `![GitHub stars](https://img.shields.io/github/stars/${userName}?style=for-the-badge&logo=github)`,
-    `![GitHub forks](https://img.shields.io/github/forks/${userName}/readme-shop?style=for-the-badge&logo=github)`,
-    `![Issues](https://img.shields.io/github/issues/${userName}/readme-shop?style=for-the-badge&logo=github)`,
+    `![GitHub forks](https://img.shields.io/github/forks/${userName}/markdown-shop?style=for-the-badge&logo=github)`,
+    `![Issues](https://img.shields.io/github/issues/${userName}/markdown-shop?style=for-the-badge&logo=github)`,
   ].join(' ');
 
 const GithubBadges = () => {
@@ -104,13 +104,13 @@ const GithubBadges = () => {
         />
         <Box
           component='img'
-          src={`https://img.shields.io/github/forks/${resolvedUserName}/readme-shop?style=for-the-badge&logo=github`}
+          src={`https://img.shields.io/github/forks/${resolvedUserName}/markdown-shop?style=for-the-badge&logo=github`}
           alt='GitHub forks badge'
           sx={{ height: 28 }}
         />
         <Box
           component='img'
-          src={`https://img.shields.io/github/issues/${resolvedUserName}/readme-shop?style=for-the-badge&logo=github`}
+          src={`https://img.shields.io/github/issues/${resolvedUserName}/markdown-shop?style=for-the-badge&logo=github`}
           alt='GitHub issues badge'
           sx={{ height: 28 }}
         />

--- a/src/features/github/components/GithubContributors.jsx
+++ b/src/features/github/components/GithubContributors.jsx
@@ -13,7 +13,7 @@ import useMarkdownStore from '@/features/markdown/store/markdownStore';
 import CardContainer from '@/components/ui/CardContainer';
 import { getGithubRepo, getGithubUser } from '../utils/githubUser';
 
-const REPO_NAME = 'readme-shop';
+const REPO_NAME = 'markdown-shop';
 
 const buildContributorsMarkdown = (repo) =>
   `<img src="https://contrib.rocks/image?repo=${repo}" alt="Contributors" style="width:100%;max-width:600px;border-radius:8px;" />`;

--- a/src/features/github/components/GithubRepoPin.jsx
+++ b/src/features/github/components/GithubRepoPin.jsx
@@ -14,7 +14,7 @@ import useMarkdownStore from '@/features/markdown/store/markdownStore';
 import CardContainer from '@/components/ui/CardContainer';
 import { getGithubUser } from '../utils/githubUser';
 
-const REPO_NAME = 'readme-shop';
+const REPO_NAME = 'markdown-shop';
 
 const buildRepoPinMarkdown = (userName) =>
   `<a href="https://github.com/${userName}/${REPO_NAME}">

--- a/src/hooks/useCachedImage.js
+++ b/src/hooks/useCachedImage.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-const CACHE_NAME = 'readme-shop-image-cache-v1';
+const CACHE_NAME = 'markdown-shop-image-cache-v1';
 
 const fetchCachedImage = async (url) => {
   if (!('caches' in window)) {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -33,25 +33,25 @@ const Home = React.memo(() => {
       }}
       aria-label='Landing Page Main Content'>
       <Helmet>
-        <title>README Shop</title>
+        <title>Markdown Shop</title>
         <meta
           name='description'
-          content='README Shop helps you create beautiful, SEO-optimized README files for your open-source projects. Try our templates, badges, and icons!'
+          content='Markdown Shop helps you create beautiful, SEO-optimized README files for your open-source projects. Try our templates, badges, and icons!'
         />
         <meta
           name='keywords'
-          content='readme-shop, README generator, open-source, badges, icons, SEO, templates'
+          content='markdown shop, README generator, open-source, badges, icons, SEO, templates'
         />
         <meta
           property='og:title'
-          content='README Shop - Create Beautiful README Files'
+          content='Markdown Shop - Create Beautiful README Files'
         />
         <meta
           property='og:description'
           content='Create beautiful, SEO-optimized README files for your open-source projects.'
         />
         <meta property='og:type' content='website' />
-        <meta property='og:url' content='https://readme-shop.com' />
+        <meta property='og:url' content='https://markdownshop.netlify.app' />
         <meta property='og:image' content='/public/favicon.svg' />
       </Helmet>
 

--- a/src/utils/config/constants.js
+++ b/src/utils/config/constants.js
@@ -3,7 +3,7 @@ export const STORAGE_KEYS = {
 };
 
 export const GITHUB_URLS = {
-  REPOSITORY: 'https://github.com/narainkarthikv/readme-shop',
+  REPOSITORY: 'https://github.com/narainkarthikv/markdown-shop',
   COMMUNITY: 'https://github.com/narainkarthikv',
 };
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -9,21 +9,21 @@ export const logger = {
   log: (...args) => {
     if (ENV.isDevelopment) {
       // eslint-disable-next-line no-console
-      console.log('[README-SHOP]', ...args);
+      console.log('[Markdown Shop]', ...args);
     }
   },
   warn: (...args) => {
     if (ENV.isDevelopment) {
-      console.warn('[README-SHOP WARNING]', ...args);
+      console.warn('[Markdown Shop WARNING]', ...args);
     }
   },
   error: (...args) => {
-    console.error('[README-SHOP ERROR]', ...args);
+    console.error('[Markdown Shop ERROR]', ...args);
   },
   info: (...args) => {
     if (ENV.isDevelopment) {
       // eslint-disable-next-line no-console
-      console.info('[README-SHOP INFO]', ...args);
+      console.info('[Markdown Shop INFO]', ...args);
     }
   },
 };


### PR DESCRIPTION
### Motivation
- Align project branding and user-facing text with the new name `Markdown Shop` to better reflect a markdown-first product focus.
- Ensure documentation, UI metadata, and deployment links consistently reference the new brand and target URLs.
- Update internal keys and generated markdown/banner text to avoid mixed names across runtime and generated content.

### Description
- Replaced occurrences of the old brand with `Markdown Shop` across docs, UI, and config, including `README.md`, `index.html`, and numerous `src/components/*` files (hero, footer, navbar, home sections, banners, etc.).
- Updated repository- and deployment-related strings and URLs to `markdown-shop` / `markdownshop` (badges, GitHub links, canonical URLs, and live/demo links) and adjusted OG/meta fields in `index.html` and page `Helmet` metadata.
- Renamed package/project identifiers and cache/storage keys: `package.json` / `package-lock.json` `name` fields set to `markdown-shop`, cache key renamed to `markdown-shop-image-cache-v1`, and storage keys updated in `src/config/index.js` and `src/utils/config/constants.js`.
- Updated generated assets and templates to match the brand, including `public/og-image.svg` (text update), SVG banner default markdown in `src/components/SvgBanners.jsx`, and repo name constants used by GitHub features in `src/features/github/*`.

### Testing
- Ran a production build with `npm run build`, which completed successfully and produced the `dist/` artifacts.
- Ran lint with `npm run lint`, which failed due to pre-existing repository lint issues (unused `eslint-disable` directives and other unrelated warnings/errors) and not caused by the rename work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9e261136c832db835991bc2ebbfaa)