### PR TITLE
feat: add AI Prompt Gallery with reusable prompt templates

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,6 +30,9 @@ const Output = lazy(
 const TemplatesPage = lazy(
   () => import(/* webpackChunkName: "templates" */ './pages/TemplatesPage')
 );
+const PromptsPage = lazy(
+  () => import(/* webpackChunkName: "prompts" */ './pages/PromptsPage')
+);
 
 /**
  * SEO Component with helmet for metadata
@@ -204,6 +207,22 @@ const App = () => {
                     transition={pageTransition}>
                     <AppLayout>
                       <TemplatesPage />
+                    </AppLayout>
+                  </motion.div>
+                }
+              />
+              <Route
+                path={ROUTES.PROMPTS}
+                element={
+                  <motion.div
+                    key='prompts'
+                    initial='initial'
+                    animate='in'
+                    exit='out'
+                    variants={pageTransitionVariants}
+                    transition={pageTransition}>
+                    <AppLayout>
+                      <PromptsPage />
                     </AppLayout>
                   </motion.div>
                 }

--- a/src/assets/data/prompts.json
+++ b/src/assets/data/prompts.json
@@ -1,0 +1,80 @@
+[
+  {
+    "label": "Bug Fix Assistant",
+    "category": "Debugging",
+    "description": "Analyze buggy code, identify the root cause, and provide a fixed version with an explanation.",
+    "content": "# 🐞 Prompt Title: Bug Fix Assistant\n\n## 🎯 Goal\nHelp debug and fix issues in the provided code.\n\n## 📥 Input\n- Programming Language:\n- Code Snippet:\n- Error Message or failing behavior:\n\n## 📤 Output\n- Root cause of the issue\n- Fixed code\n- Explanation of the fix\n\n## ⚙️ Instructions\nYou are an expert developer. Analyze the issue step-by-step and provide a clean, minimal solution."
+  },
+  {
+    "label": "Code Review Coach",
+    "category": "Coding",
+    "description": "Review code for readability, performance, and best practices with structured feedback.",
+    "content": "# 🧠 Prompt Title: Code Review Coach\n\n## 🎯 Goal\nReview the provided code and suggest improvements.\n\n## 📥 Input\n- Programming Language:\n- Code Snippet:\n- Code purpose or context:\n\n## 📤 Output\n- Summary of strengths\n- Identified issues or antipatterns\n- Recommended refactors\n- Suggested test cases\n\n## ⚙️ Instructions\nYou are a senior engineer providing polite, actionable code review feedback."
+  },
+  {
+    "label": "RAG Query Builder",
+    "category": "RAG / Retrieval",
+    "description": "Create retrieval-augmented prompts that ask for relevant knowledge from a document or knowledge base.",
+    "content": "# 🧠 Prompt Title: RAG Query Builder\n\n## 🎯 Goal\nGenerate a retrieval-augmented prompt for answering questions using external content.\n\n## 📥 Input\n- User question:\n- Context source or document summary:\n- Desired answer format:\n\n## 📤 Output\n- Focused retrieval query\n- Suggested system instructions\n- Answer formatting guidance\n\n## ⚙️ Instructions\nYou are a prompt engineer. Build a prompt that maximizes answer relevance and clarity using the provided context."
+  },
+  {
+    "label": "Learning Plan Generator",
+    "category": "Content Generation",
+    "description": "Build a personalized learning plan for a topic, including milestones and resources.",
+    "content": "# 📝 Prompt Title: Learning Plan Generator\n\n## 🎯 Goal\nCreate a structured learning plan for a topic.\n\n## 📥 Input\n- Topic:\n- Experience level:\n- Time horizon:\n- Preferred learning format:\n\n## 📤 Output\n- Learning goals\n- Weekly milestones\n- Recommended resources\n- Practice exercises\n\n## ⚙️ Instructions\nYou are an educational mentor. Craft a focused, practical study plan with clear milestones."
+  },
+  {
+    "label": "Data Analysis Summary",
+    "category": "Data Analysis",
+    "description": "Summarize datasets, identify trends, and provide actionable insights for analysis tasks.",
+    "content": "# 📊 Prompt Title: Data Analysis Summary\n\n## 🎯 Goal\nAnalyze the dataset and summarize key findings.\n\n## 📥 Input\n- Dataset description:\n- Data fields:\n- Target question or objective:\n\n## 📤 Output\n- Summary of trends\n- Key metrics\n- Insights and recommendations\n\n## ⚙️ Instructions\nYou are a data analyst. Review the dataset details and provide a concise, insightful summary."
+  },
+  {
+    "label": "AI Product Manager",
+    "category": "AI/ML",
+    "description": "Turn a business problem into AI requirements, evaluation criteria, and success metrics.",
+    "content": "# 🤖 Prompt Title: AI Product Manager\n\n## 🎯 Goal\nConvert a business need into an actionable AI product plan.\n\n## 📥 Input\n- Business objective:\n- User segment:\n- Desired outcome:\n\n## 📤 Output\n- Problem definition\n- Solution approach\n- Success metrics\n- Risks and mitigation\n\n## ⚙️ Instructions\nYou are an AI product manager. Define the scope, success criteria, and practical next steps."
+  },
+  {
+    "label": "Storytelling Assistant",
+    "category": "Content Generation",
+    "description": "Write a short story, case study, or creative narrative using a specified tone and audience.",
+    "content": "# ✍️ Prompt Title: Storytelling Assistant\n\n## 🎯 Goal\nGenerate a compelling narrative for the given topic.\n\n## 📥 Input\n- Story topic:\n- Audience:\n- Tone:\n- Length:\n\n## 📤 Output\n- Engaging story or case study\n- Key takeaways\n- Suggested title\n\n## ⚙️ Instructions\nYou are a creative writer. Keep the story vivid, on point, and aligned with the selected audience."
+  },
+  {
+    "label": "Agent Instruction Template",
+    "category": "Agent Prompts",
+    "description": "Craft clear instructions for an AI agent or assistant that performs multi-step tasks.",
+    "content": "# 🤖 Prompt Title: Agent Instruction Template\n\n## 🎯 Goal\nDefine the behavior and boundaries of an AI assistant.\n\n## 📥 Input\n- Agent role:\n- Task scope:\n- Allowed actions:\n- Output expectations:\n\n## 📤 Output\n- System instructions\n- Example interaction style\n- Failure handling\n\n## ⚙️ Instructions\nYou are designing an agent. Provide concise, deterministic rules and helpful user guidance."
+  },
+  {
+    "label": "Prompt Refinement Guide",
+    "category": "AI/ML",
+    "description": "Improve an existing prompt by making it more precise, robust, and context-aware.",
+    "content": "# 🔧 Prompt Title: Prompt Refinement Guide\n\n## 🎯 Goal\nRefine a prompt to get better results from an LLM.\n\n## 📥 Input\n- Existing prompt:\n- Target model or task:\n- Known weaknesses:\n\n## 📤 Output\n- Improved prompt version\n- Explanation of changes\n- Suggested evaluation criteria\n\n## ⚙️ Instructions\nYou are an expert prompt engineer. Strengthen the prompt with clearer instructions and stronger context."
+  },
+  {
+    "label": "Meeting Notes Summarizer",
+    "category": "Productivity",
+    "description": "Turn raw meeting notes into a polished summary with action items and decisions.",
+    "content": "# 📝 Prompt Title: Meeting Notes Summarizer\n\n## 🎯 Goal\nSummarize meeting notes into a structured recap.\n\n## 📥 Input\n- Raw notes or transcript:\n- Participants:\n- Meeting objective:\n\n## 📤 Output\n- Summary of decisions\n- Action items\n- Follow-up questions\n\n## ⚙️ Instructions\nYou are a professional summarizer. Keep the summary concise, clear, and ready to share."
+  },
+  {
+    "label": "Deployment Troubleshooter",
+    "category": "Debugging",
+    "description": "Identify deployment issues and recommend fixes based on environment details and error reports.",
+    "content": "# 🔍 Prompt Title: Deployment Troubleshooter\n\n## 🎯 Goal\nFind the root cause of a deployment failure and suggest corrective steps.\n\n## 📥 Input\n- Deployment environment:\n- Error logs or messages:\n- Deployment tooling used:\n\n## 📤 Output\n- Likely causes\n- Recommended fixes\n- Verification steps\n\n## ⚙️ Instructions\nYou are an operations expert. Diagnose the failure clearly and prioritize the most reliable fix."
+  },
+  {
+    "label": "Training Data Audit",
+    "category": "AI/ML",
+    "description": "Review training data requirements, risks, and ethical considerations for an ML model.",
+    "content": "# 🧠 Prompt Title: Training Data Audit\n\n## 🎯 Goal\nAudit training data for quality, bias, and coverage.\n\n## 📥 Input\n- Dataset description:\n- Model objective:\n- Known risks or constraints:\n\n## 📤 Output\n- Data quality concerns\n- Bias and fairness issues\n- Recommendations for collection or filtering\n\n## ⚙️ Instructions\nYou are an ML ethicist. Evaluate the dataset honestly and suggest improvements."
+  },
+  {
+    "label": "Release Notes Writer",
+    "category": "Content Generation",
+    "description": "Summarize product updates and improvements into release note copy.",
+    "content": "# 📝 Prompt Title: Release Notes Writer\n\n## 🎯 Goal\nWrite clear release notes for a product update.\n\n## 📥 Input\n- Release version:\n- New features:\n- Bug fixes:\n- Improvements:\n\n## 📤 Output\n- Summary paragraph\n- Feature highlights\n- Notes for users\n\n## ⚙️ Instructions\nYou are a product writer. Create release notes that are easy to scan and framed for end users."
+  }
+]

--- a/src/components/CustomDrawer.jsx
+++ b/src/components/CustomDrawer.jsx
@@ -19,7 +19,8 @@ import { Link } from 'react-router-dom';
 const navigationItems = [
   { label: 'Home', icon: <HomeIcon />, path: '/' },
   { label: 'Github Components', icon: <FaObjectGroup />, path: '/components' },
-  { label: 'Templates', icon: <MenuBookIcon />, path: '/templates' },
+  { label: 'Markdown Templates', icon: <MenuBookIcon />, path: '/templates' },
+  { label: 'Prompt Gallery', icon: <MenuBookIcon />, path: '/prompts' },
 ];
 
 const CustomDrawer = ({ open, onClose, currentPath }) => {

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -7,7 +7,8 @@ const footerLinks = [
     title: 'Project',
     links: [
       { label: 'Open app', to: '/shop', internal: true },
-      { label: 'Templates', to: '/templates', internal: true },
+      { label: 'Markdown Templates', to: '/templates', internal: true },
+      { label: 'Prompt Gallery', to: '/prompts', internal: true },
       { label: 'Components', to: '/components', internal: true },
       {
         label: 'GitHub repo',

--- a/src/components/Home/CtaSection.jsx
+++ b/src/components/Home/CtaSection.jsx
@@ -60,7 +60,7 @@ const CtaSection = () => {
                   variant='outlined'
                   color='primary'
                   sx={{ px: 3.5, borderRadius: 3 }}>
-                  View Templates
+                  View Markdown Templates
                 </Button>
               </Stack>
             </Grid>

--- a/src/components/Home/FeaturesSection.jsx
+++ b/src/components/Home/FeaturesSection.jsx
@@ -14,15 +14,15 @@ const features = [
     icon: '01',
   },
   {
-    title: 'Badges that matter',
+    title: 'Prompt Gallery',
     description:
-      'Highlight releases, license, CI status, and community trust signals.',
+      'Reusable AI prompts for debugging, content, and product workflows.',
     icon: '02',
   },
   {
-    title: 'Icons + skill stack',
+    title: 'Badges that matter',
     description:
-      'Add recognizable tech logos and skill rows with clean spacing.',
+      'Highlight releases, license, CI status, and community trust signals.',
     icon: '03',
   },
   {

--- a/src/components/Home/HeroSection.jsx
+++ b/src/components/Home/HeroSection.jsx
@@ -18,15 +18,15 @@ import {
 } from './animations';
 
 const heroStats = [
-  { label: 'Templates', value: '40+' },
-  { label: 'Badges', value: '120+' },
+  { label: 'Markdown Templates', value: '40+' },
+  { label: 'Prompt Gallery', value: '12+' },
   { label: 'Icons', value: '300+' },
 ];
 
 const highlights = [
-  'Templates tuned for apps and libraries',
-  'Badges, stats, and icons in one flow',
-  'Export clean Markdown in minutes',
+  'Choose from markdown templates and AI prompts',
+  'Build docs with badges, stats, and live preview',
+  'Export ready-to-publish markdown in seconds',
 ];
 
 const HeroSection = () => {
@@ -66,7 +66,7 @@ const HeroSection = () => {
             <Grid item xs={12} md={6}>
               <motion.div variants={textRevealVariants} custom={0}>
                 <Chip
-                  label='New: curated templates + stats'
+                  label='New: Prompt Gallery + Markdown Templates'
                   color='primary'
                   variant='outlined'
                   sx={{
@@ -110,9 +110,9 @@ const HeroSection = () => {
                     maxWidth: 520,
                     mb: 3,
                   }}>
-                  Structure your README with confidence. Build clean,
-                  ready-to-publish documentation using guided templates and live
-                  previews.
+                  Structure your README the SaaS way. Build clean,
+                  ready-to-publish documentation using Markdown Templates,
+                  AI prompts, and live preview.
                 </Typography>
               </motion.div>
 
@@ -134,7 +134,7 @@ const HeroSection = () => {
                     color='primary'
                     size='large'
                     sx={{ px: 3.5, borderRadius: 3 }}>
-                    Browse Templates
+                    Browse Markdown Templates
                   </Button>
                 </Stack>
               </motion.div>
@@ -189,13 +189,13 @@ const HeroSection = () => {
                   <Typography
                     variant='h4'
                     sx={{ fontWeight: 700, mt: 1, mb: 1 }}>
-                    A modern README, ready to ship
+                    Your documentation workflow, built like a SaaS app
                   </Typography>
                   <Typography
                     variant='body2'
                     sx={{ color: theme.palette.text.secondary, mb: 3 }}>
-                    See how your README looks with badges, stats, and a clear
-                    structure.
+                    Preview Markdown live, apply reusable templates and prompts,
+                    and ship docs with confidence.
                   </Typography>
                   <Stack spacing={1.5} sx={{ mb: 3 }}>
                     {highlights.map((item) => (

--- a/src/components/Home/HowItWorksSection.jsx
+++ b/src/components/Home/HowItWorksSection.jsx
@@ -12,17 +12,19 @@ import SectionTitle from './components/SectionTitle';
 
 const steps = [
   {
-    title: 'Start with a layout',
-    description: 'Pick a template built for your project type and audience.',
-  },
-  {
-    title: 'Add your story',
+    title: 'Start with a template or prompt',
     description:
-      'Drop in badges, icons, screenshots, and stats to build credibility.',
+      'Choose Markdown Templates or AI prompts built for docs, and workflow notes.',
   },
   {
-    title: 'Export clean Markdown',
-    description: 'Copy, export, and publish to GitHub with zero cleanup.',
+    title: 'Personalize the page',
+    description:
+      'Add badges, icons, stats, and rich sections with live preview feedback.',
+  },
+  {
+    title: 'Publish with confidence',
+    description:
+      'Export clean Markdown, copy it instantly, and ship polished project docs.',
   },
 ];
 

--- a/src/components/Home/InfoSection.jsx
+++ b/src/components/Home/InfoSection.jsx
@@ -13,10 +13,10 @@ const infoItems = [
       'Turn complex work into a README that is easy to skim and simple to trust.',
   },
   {
-    icon: 'Modular blocks',
-    title: 'Build with reusable pieces',
+    icon: 'Prompt-ready',
+    title: 'Use AI prompt templates',
     description:
-      'Mix templates, badges, icons, and stats without rebuilding your structure.',
+      'Jump-start your writing with structured prompts built for debugging, and documentation.',
   },
   {
     icon: 'Export ready',
@@ -41,9 +41,8 @@ const InfoSection = () => {
           mx: 'auto',
           mb: 5,
         }}>
-        Give your open-source work a professional, trustworthy home. Build a
-        README that invites contributors and makes your project feel ready for
-        the spotlight.
+        Turn README writing into a polished SaaS workflow. Use Markdown Templates,
+        AI prompts, badges, and stats to move from idea to launch without friction.
       </Typography>
 
       <Grid container spacing={3}>
@@ -89,10 +88,10 @@ const InfoSection = () => {
         </Button>
         <Button
           component={Link}
-          to='/components'
+          to='/prompts'
           variant='outlined'
           color='primary'>
-          Explore Components
+          Explore Prompt Gallery
         </Button>
       </Stack>
     </Section>

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -64,6 +64,7 @@ export const ROUTES = {
   COMPONENTS: '/components',
   SHOP: '/shop',
   TEMPLATES: '/templates',
+  PROMPTS: '/prompts',
   OUTPUT: '/output',
   NOT_FOUND: '*',
 };

--- a/src/features/prompts/PromptLayout.jsx
+++ b/src/features/prompts/PromptLayout.jsx
@@ -1,17 +1,10 @@
-import { Box, Container, Paper, useTheme, alpha } from '@mui/material';
+import React from 'react';
 import PropTypes from 'prop-types';
+import { Box, Container, Paper, useTheme } from '@mui/material';
 import ModernSection from '@/components/ui/ModernSection';
-import TemplatesGrid from '@/components/Templates/TemplatesGrid';
+import PromptGrid from './components/PromptGrid';
 
-/**
- * TemplatesLayout - Modern 2026+ Design
- * Features:
- * - Clean containerized layout matching Components page
- * - Proper spacing and responsive design
- * - Modern visual hierarchy
- * - Optimized for user experience
- */
-const TemplatesLayout = ({ children }) => {
+const PromptLayout = ({ children }) => {
   const theme = useTheme();
 
   return (
@@ -27,10 +20,9 @@ const TemplatesLayout = ({ children }) => {
           py: { xs: 3, md: 4 },
           px: { xs: 2, md: 3 },
         }}>
-        {/* Modern Section Wrapper */}
         <ModernSection
-          title='Markdown Templates'
-          description='Choose from professionally crafted templates to kickstart your project documentation'
+          title='AI Prompt Gallery'
+          description='Browse reusable structured prompt templates for coding, debugging, content generation, and AI workflows.'
           variant='default'
           sx={{ mb: 2 }}>
           <Paper
@@ -41,7 +33,7 @@ const TemplatesLayout = ({ children }) => {
               bgcolor: 'background.paper',
               border: `1px solid ${theme.customTokens?.borderSubtle || theme.palette.divider}`,
             }}>
-            <TemplatesGrid />
+            <PromptGrid />
           </Paper>
         </ModernSection>
 
@@ -51,8 +43,8 @@ const TemplatesLayout = ({ children }) => {
   );
 };
 
-TemplatesLayout.propTypes = {
+PromptLayout.propTypes = {
   children: PropTypes.node,
 };
 
-export default TemplatesLayout;
+export default PromptLayout;

--- a/src/features/prompts/components/PromptCard.jsx
+++ b/src/features/prompts/components/PromptCard.jsx
@@ -1,0 +1,479 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Typography,
+  Paper,
+  Card,
+  CardContent,
+  Box,
+  Chip,
+  alpha,
+  ButtonGroup,
+  Button,
+  Tooltip,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  IconButton,
+  Divider,
+} from '@mui/material';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import AddIcon from '@mui/icons-material/Add';
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import { useTheme } from '@mui/material/styles';
+import useClipboard from '@/hooks/useClipboard';
+
+const PromptCardHeader = React.memo(
+  ({ prompt, category, onCopy, onUse, onPreview, copied }) => {
+    const theme = useTheme();
+
+    return (
+      <Box
+        sx={{
+          p: 2.5,
+          pb: 1.5,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          gap: 1.5,
+        }}>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography
+            variant='h6'
+            component='h3'
+            sx={{
+              fontWeight: 600,
+              fontSize: { xs: '1rem', sm: '1.1rem' },
+              color: 'text.primary',
+              mb: category && category !== 'all' ? 0.5 : 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+            }}
+            itemProp='name'>
+            {prompt.label}
+          </Typography>
+
+          {category && category !== 'all' && (
+            <Chip
+              label={category}
+              size='small'
+              sx={{
+                height: 20,
+                fontSize: '0.65rem',
+                fontWeight: 500,
+                bgcolor: alpha(theme.palette.primary.main, 0.1),
+                color: 'primary.main',
+                border: `1px solid ${alpha(theme.palette.primary.main, 0.2)}`,
+              }}
+            />
+          )}
+        </Box>
+
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Tooltip title='Preview prompt' arrow>
+            <IconButton
+              onClick={onPreview}
+              size='small'
+              sx={{
+                color: 'primary.main',
+                '&:hover': {
+                  bgcolor: alpha(theme.palette.primary.main, 0.1),
+                },
+              }}
+              aria-label='Preview prompt'>
+              <VisibilityIcon fontSize='small' />
+            </IconButton>
+          </Tooltip>
+          <ButtonGroup size='small' variant='contained'>
+            <Tooltip title={copied ? 'Copied!' : 'Copy to clipboard'} arrow>
+              <Button
+                onClick={onCopy}
+                color={copied ? 'success' : 'primary'}
+                sx={{ minWidth: 'auto', px: 1.5 }}
+                aria-label={
+                  copied ? 'Copied to clipboard' : 'Copy prompt to clipboard'
+                }>
+                {copied ? <CheckIcon fontSize='small' /> : <ContentCopyIcon fontSize='small' />}
+              </Button>
+            </Tooltip>
+            <Tooltip title='Use prompt in editor' arrow>
+              <Button
+                onClick={onUse}
+                color='primary'
+                sx={{ minWidth: 'auto', px: 1.5 }}
+                aria-label='Use prompt in editor'>
+                <AddIcon fontSize='small' />
+              </Button>
+            </Tooltip>
+          </ButtonGroup>
+        </Box>
+      </Box>
+    );
+  }
+);
+
+PromptCardHeader.displayName = 'PromptCardHeader';
+
+PromptCardHeader.propTypes = {
+  prompt: PropTypes.shape({
+    label: PropTypes.string.isRequired,
+  }).isRequired,
+  category: PropTypes.string,
+  onCopy: PropTypes.func.isRequired,
+  onUse: PropTypes.func.isRequired,
+  onPreview: PropTypes.func.isRequired,
+  copied: PropTypes.bool,
+};
+
+const PromptPreview = React.memo(({ content, expanded = false }) => {
+  const theme = useTheme();
+
+  return (
+    <Paper
+      variant='outlined'
+      sx={{
+        background: alpha(theme.palette.background.default, 0.6),
+        color: theme.palette.text.primary,
+        p: 2,
+        borderRadius: 1.5,
+        overflowX: 'auto',
+        overflowY: 'auto',
+        fontSize: '0.85rem',
+        minHeight: expanded ? 180 : 100,
+        maxHeight: expanded ? 300 : 140,
+        border: `1px solid ${theme.customTokens?.borderSubtle || theme.palette.divider}`,
+        transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+        '&:hover': {
+          bgcolor: alpha(theme.palette.background.default, 0.8),
+          borderColor: theme.customTokens?.border || theme.palette.divider,
+        },
+        '&::-webkit-scrollbar': {
+          width: 6,
+          height: 6,
+        },
+        '&::-webkit-scrollbar-thumb': {
+          bgcolor: alpha(theme.palette.text.secondary, 0.3),
+          borderRadius: 3,
+        },
+      }}
+      role='textbox'
+      aria-readonly='true'
+      tabIndex={0}>
+      <Box
+        component='pre'
+        itemProp='text'
+        sx={{
+          margin: 0,
+          fontFamily:
+            'ui-monospace, SFMono-Regular, SF Mono, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+          lineHeight: 1.6,
+        }}>
+        {content}
+      </Box>
+    </Paper>
+  );
+});
+
+PromptPreview.displayName = 'PromptPreview';
+
+PromptPreview.propTypes = {
+  content: PropTypes.string.isRequired,
+  expanded: PropTypes.bool,
+};
+
+const PromptCard = ({
+  prompt,
+  index,
+  selectedIdx,
+  copiedIdx,
+  onUsePrompt,
+  onCopy,
+  viewMode = 'grid',
+}) => {
+  const theme = useTheme();
+  const [isHovered, setIsHovered] = useState(false);
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const { copied, copyToClipboard } = useClipboard();
+
+  const isSelected = selectedIdx === index;
+  const isListView = viewMode === 'list';
+
+  const handleCopy = async () => {
+    await copyToClipboard(prompt.content, { contentType: 'text/plain' });
+    onCopy(prompt.content, index);
+  };
+
+  const handleUse = () => {
+    onUsePrompt(prompt.content, index);
+    setPreviewOpen(false);
+  };
+
+  const handlePreviewOpen = () => setPreviewOpen(true);
+  const handlePreviewClose = () => setPreviewOpen(false);
+
+  return (
+    <>
+      <Card
+        sx={{
+          width: '100%',
+          minHeight: isListView ? 200 : 320,
+          height: isListView ? 'auto' : { xs: 320, sm: 360 },
+          display: 'flex',
+          flexDirection: isListView ? 'row' : 'column',
+          justifyContent: 'flex-start',
+          bgcolor: 'background.paper',
+          border: `1px solid ${
+            isSelected
+              ? theme.palette.primary.main
+              : theme.customTokens?.borderSubtle || theme.palette.divider
+          }`,
+          borderRadius: 2,
+          position: 'relative',
+          transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+          overflow: 'hidden',
+          '&:hover': {
+            transform: 'translateY(-4px)',
+            boxShadow: theme.customTokens?.shadow?.md || theme.shadows[6],
+            borderColor: isSelected
+              ? theme.palette.primary.main
+              : theme.customTokens?.border || theme.palette.divider,
+          },
+          '&::before': isSelected
+            ? {
+                content: '""',
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                right: 0,
+                height: 4,
+                bgcolor: 'primary.main',
+                zIndex: 1,
+              }
+            : {},
+        }}
+        component='article'
+        itemScope
+        itemType='https://schema.org/CreativeWork'
+        aria-label={`Prompt: ${prompt.label}`}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}>
+        {isSelected && !isHovered && (
+          <Box
+            sx={{
+              position: 'absolute',
+              top: 12,
+              right: 12,
+              zIndex: 2,
+              bgcolor: 'success.main',
+              color: 'success.contrastText',
+              borderRadius: 1,
+              p: 0.5,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              boxShadow: theme.shadows[2],
+            }}>
+            <CheckCircleIcon sx={{ fontSize: 20 }} />
+          </Box>
+        )}
+
+        <Box
+          sx={{
+            flex: isListView ? '0 0 auto' : 1,
+            width: isListView ? { xs: '100%', sm: '50%' } : '100%',
+            display: 'flex',
+            flexDirection: 'column',
+          }}>
+          <PromptCardHeader
+            prompt={prompt}
+            category={prompt.category}
+            onCopy={handleCopy}
+            onUse={handleUse}
+            onPreview={handlePreviewOpen}
+            copied={copied}
+          />
+
+          <CardContent
+            sx={{
+              pt: 0,
+              px: 2.5,
+              pb: 2,
+              flexGrow: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'flex-start',
+            }}>
+            <Typography
+              variant='body2'
+              sx={{
+                mb: 2,
+                minHeight: isListView ? 'auto' : 40,
+                color: 'text.secondary',
+                lineHeight: 1.6,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                display: '-webkit-box',
+                WebkitLineClamp: isListView ? 2 : 2,
+                WebkitBoxOrient: 'vertical',
+              }}
+              itemProp='description'>
+              {prompt.description}
+            </Typography>
+
+            {!isListView && <PromptPreview content={prompt.content} />}
+          </CardContent>
+        </Box>
+
+        {isListView && (
+          <Box
+            sx={{
+              flex: 1,
+              p: 2.5,
+              pt: 3.5,
+              bgcolor: alpha(theme.palette.background.default, 0.4),
+              borderLeft: `1px solid ${theme.customTokens?.borderSubtle || theme.palette.divider}`,
+            }}>
+            <PromptPreview content={prompt.content} expanded />
+          </Box>
+        )}
+      </Card>
+
+      <Dialog
+        open={previewOpen}
+        onClose={handlePreviewClose}
+        maxWidth='md'
+        fullWidth
+        scroll='paper'
+        PaperProps={{
+          sx: {
+            borderRadius: 2,
+            position: 'fixed',
+            maxHeight: '85vh',
+            display: 'flex',
+            overflow: 'hidden',
+          },
+        }}>
+        <DialogTitle
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            pb: 2,
+          }}>
+          <Box>
+            <Typography variant='h6' sx={{ fontWeight: 600, mb: 0.5 }}>
+              {prompt.label}
+            </Typography>
+            {prompt.category && prompt.category !== 'all' && (
+              <Chip
+                label={prompt.category}
+                size='small'
+                sx={{
+                  height: 22,
+                  fontSize: '0.7rem',
+                  bgcolor: alpha(theme.palette.primary.main, 0.1),
+                  color: 'primary.main',
+                }}
+              />
+            )}
+          </Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <ButtonGroup variant='contained' size='small'>
+              <Button
+                onClick={handleCopy}
+                startIcon={copied ? <CheckIcon /> : <ContentCopyIcon />}
+                color={copied ? 'success' : 'primary'}
+                sx={{ borderRadius: '6px 0 0 6px' }}>
+                {copied ? 'Copied' : 'Copy'}
+              </Button>
+              <Button
+                onClick={handleUse}
+                startIcon={<AddIcon />}
+                color='primary'
+                sx={{ borderRadius: '0 6px 6px 0' }}>
+                Use Prompt
+              </Button>
+            </ButtonGroup>
+            <IconButton
+              onClick={handlePreviewClose}
+              size='small'
+              sx={{
+                color: 'text.secondary',
+                '&:hover': { bgcolor: alpha(theme.palette.text.secondary, 0.1) },
+              }}>
+              <CloseIcon />
+            </IconButton>
+          </Box>
+        </DialogTitle>
+
+        <Divider />
+
+        <DialogContent sx={{ pt: 3, overflowY: 'auto' }}>
+          <Typography variant='body2' color='text.secondary' sx={{ mb: 3, lineHeight: 1.7 }}>
+            {prompt.description}
+          </Typography>
+
+          <Paper
+            variant='outlined'
+            sx={{
+              p: 3,
+              borderRadius: 2,
+              bgcolor: alpha(theme.palette.background.default, 0.6),
+              border: `1px solid ${theme.customTokens?.borderSubtle || theme.palette.divider}`,
+              maxHeight: 450,
+              overflow: 'auto',
+              '&::-webkit-scrollbar': {
+                width: 8,
+              },
+              '&::-webkit-scrollbar-thumb': {
+                bgcolor: alpha(theme.palette.text.secondary, 0.3),
+                borderRadius: 4,
+              },
+            }}>
+            <Box
+              component='pre'
+              sx={{
+                margin: 0,
+                fontFamily:
+                  'ui-monospace, SFMono-Regular, SF Mono, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+                fontSize: '0.875rem',
+                lineHeight: 1.7,
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+                color: 'text.primary',
+              }}>
+              {prompt.content}
+            </Box>
+          </Paper>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+PromptCard.displayName = 'PromptCard';
+
+PromptCard.propTypes = {
+  prompt: PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    content: PropTypes.string.isRequired,
+    category: PropTypes.string,
+  }).isRequired,
+  selectedIdx: PropTypes.number,
+  index: PropTypes.number.isRequired,
+  copiedIdx: PropTypes.number,
+  onUsePrompt: PropTypes.func.isRequired,
+  onCopy: PropTypes.func.isRequired,
+  viewMode: PropTypes.oneOf(['grid', 'list']),
+};
+
+export default React.memo(PromptCard);

--- a/src/features/prompts/components/PromptGrid.jsx
+++ b/src/features/prompts/components/PromptGrid.jsx
@@ -1,0 +1,183 @@
+import React, { useMemo } from 'react';
+import {
+  Box,
+  Typography,
+  Grid,
+  Fade,
+  ToggleButton,
+  ToggleButtonGroup,
+  Stack,
+  Divider,
+  useTheme,
+  alpha,
+  InputAdornment,
+} from '@mui/material';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
+import ViewListIcon from '@mui/icons-material/ViewList';
+import SearchIcon from '@mui/icons-material/Search';
+import PromptCard from './PromptCard';
+import TemplateCategories from '@/features/templates/components/TemplateCategories';
+import SearchField from '@/components/ui/SearchField';
+import { NoSearchResults } from '@/components/ui/EmptyState';
+import { usePrompts } from '@/hooks/usePrompts';
+
+const PromptGrid = () => {
+  const theme = useTheme();
+  const {
+    prompts,
+    categories,
+    search,
+    setSearch,
+    selectedCategory,
+    setSelectedCategory,
+    selectedIdx,
+    copiedIdx,
+    handleCopy,
+    handleUsePrompt,
+  } = usePrompts();
+
+  const [view, setView] = React.useState('grid');
+
+  const handleViewChange = (_, next) => {
+    if (next) setView(next);
+  };
+
+  const handleClearFilters = () => {
+    setSearch('');
+    setSelectedCategory('all');
+  };
+
+  const gridColumns = useMemo(() => {
+    return view === 'list' ? { xs: 12 } : { xs: 12, sm: 6, lg: 4 };
+  }, [view]);
+
+  const hasActiveFilters = search.trim() !== '' || selectedCategory !== 'all';
+
+  return (
+    <Box sx={{ width: '100%' }}>
+      <Box sx={{ mb: 3 }}>
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={2}
+          alignItems={{ xs: 'stretch', sm: 'center' }}
+          justifyContent='space-between'>
+          <SearchField
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder='Search prompts by name, description, or content...'
+            sx={{ mb: 0, flex: 1, maxWidth: { sm: 600 } }}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position='start'>
+                  <SearchIcon sx={{ color: 'text.secondary' }} />
+                </InputAdornment>
+              ),
+            }}
+          />
+
+          <ToggleButtonGroup
+            value={view}
+            exclusive
+            onChange={handleViewChange}
+            size='small'
+            sx={{
+              alignSelf: { xs: 'flex-end', sm: 'center' },
+              bgcolor: alpha(theme.palette.background.default, 0.5),
+            }}
+            aria-label='View mode'>
+            <ToggleButton value='grid' aria-label='Grid view'>
+              <ViewModuleIcon fontSize='small' />
+            </ToggleButton>
+            <ToggleButton value='list' aria-label='List view'>
+              <ViewListIcon fontSize='small' />
+            </ToggleButton>
+          </ToggleButtonGroup>
+        </Stack>
+      </Box>
+
+      <Box sx={{ mb: 3 }}>
+        <Typography
+          variant='subtitle2'
+          sx={{
+            mb: 1.5,
+            fontWeight: 600,
+            color: 'text.secondary',
+            textTransform: 'uppercase',
+            letterSpacing: 0.5,
+            fontSize: '0.75rem',
+          }}>
+          Categories
+        </Typography>
+        <TemplateCategories
+          categories={categories}
+          selectedCategory={selectedCategory}
+          onCategorySelect={setSelectedCategory}
+        />
+      </Box>
+
+      <Divider sx={{ my: 3 }} />
+
+      {prompts.length === 0 ? (
+        <NoSearchResults
+          action={
+            hasActiveFilters ? (
+              <Box
+                component='button'
+                onClick={handleClearFilters}
+                sx={{
+                  px: 3,
+                  py: 1.5,
+                  border: 'none',
+                  borderRadius: 2,
+                  bgcolor: 'primary.main',
+                  color: 'primary.contrastText',
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                  transition: 'all 0.2s',
+                  '&:hover': {
+                    bgcolor: 'primary.dark',
+                  },
+                }}>
+                Clear Filters
+              </Box>
+            ) : null
+          }
+        />
+      ) : (
+        <>
+          <Typography
+            variant='body2'
+            sx={{
+              mb: 2,
+              color: 'text.secondary',
+              fontWeight: 500,
+            }}>
+            Showing {prompts.length} prompt{prompts.length !== 1 ? 's' : ''}
+          </Typography>
+
+          <Grid container spacing={{ xs: 2, md: 3 }} alignItems='stretch'>
+            {prompts.map((prompt, idx) => (
+              <Grid item key={prompt.label} {...gridColumns} sx={{ display: 'flex' }}>
+                <Fade in timeout={300 + idx * 50} style={{ width: '100%' }}>
+                  <div style={{ width: '100%', display: 'flex' }}>
+                    <PromptCard
+                      prompt={prompt}
+                      index={idx}
+                      selectedIdx={selectedIdx}
+                      copiedIdx={copiedIdx}
+                      onUsePrompt={handleUsePrompt}
+                      onCopy={handleCopy}
+                      viewMode={view}
+                    />
+                  </div>
+                </Fade>
+              </Grid>
+            ))}
+          </Grid>
+        </>
+      )}
+    </Box>
+  );
+};
+
+export default PromptGrid;

--- a/src/features/prompts/store/promptsStore.js
+++ b/src/features/prompts/store/promptsStore.js
@@ -1,0 +1,37 @@
+import { create } from 'zustand';
+import promptsData from '@/assets/data/prompts.json';
+
+const usePromptsStore = create((set, get) => ({
+  prompts: promptsData,
+  search: '',
+  selectedCategory: 'all',
+  selectedIdx: null,
+  copiedIdx: null,
+  setSearch: (search) => set({ search }),
+  setSelectedCategory: (category) => set({ selectedCategory: category }),
+  setSelectedIdx: (idx) => set({ selectedIdx: idx }),
+  setCopiedIdx: (idx) => set({ copiedIdx: idx }),
+  getFilteredPrompts: () => {
+    const { prompts, search, selectedCategory } = get();
+    return prompts.filter((prompt) => {
+      const normalizedSearch = search.toLowerCase();
+      const matchesSearch =
+        prompt.label.toLowerCase().includes(normalizedSearch) ||
+        prompt.description.toLowerCase().includes(normalizedSearch) ||
+        prompt.content.toLowerCase().includes(normalizedSearch);
+      const matchesCategory =
+        selectedCategory === 'all' || prompt.category === selectedCategory;
+      return matchesSearch && matchesCategory;
+    });
+  },
+  getCategories: () => {
+    const { prompts } = get();
+    const categories = ['all', ...new Set(prompts.map((prompt) => prompt.category))];
+    return categories.map((category) => ({
+      value: category,
+      label: category === 'all' ? 'All' : category,
+    }));
+  },
+}));
+
+export default usePromptsStore;

--- a/src/hooks/usePrompts.js
+++ b/src/hooks/usePrompts.js
@@ -1,0 +1,59 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import useMarkdownStore from '@/features/markdown/store/markdownStore';
+import usePromptsStore from '@/features/prompts/store/promptsStore';
+import useClipboard from './useClipboard';
+
+export const usePrompts = () => {
+  const navigate = useNavigate();
+  const { copyToClipboard } = useClipboard();
+  const { setMarkdown } = useMarkdownStore();
+  const {
+    search,
+    setSearch,
+    selectedCategory,
+    setSelectedCategory,
+    selectedIdx,
+    setSelectedIdx,
+    copiedIdx,
+    setCopiedIdx,
+    getFilteredPrompts,
+    getCategories,
+  } = usePromptsStore();
+
+  const handleCopy = useCallback(
+    async (content, idx) => {
+      try {
+        await copyToClipboard(content);
+        setCopiedIdx(idx);
+        setTimeout(() => setCopiedIdx(null), 2000);
+      } catch (err) {
+        console.error('Failed to copy prompt: ', err);
+      }
+    },
+    [copyToClipboard, setCopiedIdx]
+  );
+
+  const handleUsePrompt = useCallback(
+    (content, idx) => {
+      setMarkdown(content);
+      setSelectedIdx(idx);
+      navigate('/shop');
+      setTimeout(() => setSelectedIdx(null), 2000);
+    },
+    [navigate, setMarkdown, setSelectedIdx]
+  );
+
+  return {
+    prompts: getFilteredPrompts(),
+    categories: getCategories(),
+    search,
+    setSearch,
+    selectedCategory,
+    setSelectedCategory,
+    selectedIdx,
+    copiedIdx,
+    handleCopy,
+    handleUsePrompt,
+  };
+};

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -36,19 +36,19 @@ const Home = React.memo(() => {
         <title>Markdown Shop</title>
         <meta
           name='description'
-          content='Markdown Shop helps you create beautiful, SEO-optimized README files for your open-source projects. Try our templates, badges, and icons!'
+          content='Markdown Shop is a SaaS-style README builder with Markdown Templates, AI Prompt Gallery, badges, icons, and live preview for modern project docs.'
         />
         <meta
           name='keywords'
-          content='markdown shop, README generator, open-source, badges, icons, SEO, templates'
+          content='markdown shop, README builder, markdown templates, prompt gallery, SaaS, documentation, badges, icons'
         />
         <meta
           property='og:title'
-          content='Markdown Shop - Create Beautiful README Files'
+          content='Markdown Shop - SaaS-grade README Builder'
         />
         <meta
           property='og:description'
-          content='Create beautiful, SEO-optimized README files for your open-source projects.'
+          content='Build polished README docs faster with Markdown Templates, reusable prompts, live preview, and export-ready markdown.'
         />
         <meta property='og:type' content='website' />
         <meta property='og:url' content='https://markdownshop.netlify.app' />

--- a/src/pages/PromptsPage.jsx
+++ b/src/pages/PromptsPage.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import PromptLayout from '@/features/prompts/PromptLayout';
+
+const PromptsPage = React.memo(() => <PromptLayout />);
+
+PromptsPage.displayName = 'PromptsPage';
+
+export default PromptsPage;


### PR DESCRIPTION
## Description

Adds a new AI Prompt Gallery to Markdown Shop with reusable structured prompt templates for coding, debugging, content generation, AI/ML workflows, productivity, and documentation use cases.

This PR introduces a dedicated `/prompts` route, prompt data, searchable/filterable gallery UI, grid/list views, prompt preview dialogs, clipboard copy support, and the ability to send a selected prompt into the markdown editor. It also updates homepage, drawer, footer, and SEO copy to position Markdown Shop around Markdown Templates plus the new Prompt Gallery.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant documentation, if needed.

## Related Issue

Fixes #42

## Screenshots (if applicable)

<!-- Add screenshots to explain your changes visually. -->

## Additional Notes

Changes include:

- Added `/prompts` route and lazy-loaded `PromptsPage`.
- Added prompt dataset with 12 reusable AI prompt templates.
- Added prompt gallery layout, grid/list toggle, category filters, search, preview modal, copy action, and “use prompt” action.
- Added Zustand prompt store and `usePrompts` hook.
- Updated navigation labels to distinguish Markdown Templates from Prompt Gallery.
- Updated homepage messaging, feature highlights, CTA copy, and SEO metadata.