### PR TITLE
Bump version to 1.1.3 and improve markdown editor components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [1.1.3] - 2026-07-18
+
+### Fixed
+
+- Fixed markdown editor and preview containers scrollability in `/shop` section
+  - Added `minHeight: 0` to flex containers to enable proper scrolling
+  - Replaced MUI TextField with native textarea for reliable scroll behavior
+  - Updated Paper background color to match outer container for consistent design
+  - Ensured both containers scroll independently with proper overflow handling
+  - Improved responsive layout for mobile devices
+
 ## [1.1.2] - 2026-06-30
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "markdown-shop",
   "private": true,
-  "version": "1.1.2",
+  "version": "1.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/src/features/markdown/components/MarkdownEditor.jsx
+++ b/src/features/markdown/components/MarkdownEditor.jsx
@@ -1,50 +1,51 @@
 import React from 'react';
-import { TextField, Paper, Typography } from '@mui/material';
+import { Paper, Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import PropTypes from 'prop-types';
 
-const MarkdownEditor = ({ value, onChange }) => (
-  <Paper
-    elevation={3}
-    sx={{
-      flex: 1,
-      display: 'flex',
-      flexDirection: 'column',
-      p: 2,
-      minHeight: 0,
-      maxWidth: '50%',
-      position: 'relative',
-      '& .MuiInputBase-root': {
-        fontFamily: 'monospace',
-        height: '100%',
-      },
-    }}>
-    <Typography variant='h6' sx={{ mb: 1, flexShrink: 0 }}>
-      Markdown Editor
-    </Typography>
-    <TextField
-      multiline
-      value={value}
-      onChange={onChange}
-      fullWidth
-      variant='outlined'
-      placeholder='Write your README markdown here...'
+const MarkdownEditor = ({ value, onChange }) => {
+  const theme = useTheme();
+
+  return (
+    <Paper
+      elevation={3}
       sx={{
         flex: 1,
-        '& .MuiInputBase-root': {
-          height: '100%',
-          display: 'flex',
-          alignItems: 'flex-start',
-          '& textarea': {
-            flex: 1,
-            resize: 'none',
-            overflowY: 'auto',
-            paddingTop: '8px',
-          },
-        },
-      }}
-    />
-  </Paper>
-);
+        display: 'flex',
+        flexDirection: 'column',
+        p: 2,
+        minHeight: 0,
+        minWidth: 0,
+        overflow: 'hidden',
+        position: 'relative',
+        bgcolor: theme.palette.background.default,
+      }}>
+      <Typography variant='h6' sx={{ mb: 1, flexShrink: 0 }}>
+        Markdown Editor
+      </Typography>
+      <textarea
+        value={value}
+        onChange={onChange}
+        placeholder='Write your README markdown here...'
+        style={{
+          flex: 1,
+          minHeight: 0,
+          width: '100%',
+          padding: '12px',
+          fontFamily: 'monospace',
+          fontSize: '14px',
+          border: `1px solid ${theme.palette.divider}`,
+          borderRadius: '4px',
+          resize: 'none',
+          overflowY: 'auto',
+          boxSizing: 'border-box',
+          backgroundColor: theme.palette.background.paper,
+          color: theme.palette.text.primary,
+        }}
+      />
+    </Paper>
+  );
+};
 
 MarkdownEditor.propTypes = {
   value: PropTypes.string.isRequired,

--- a/src/features/markdown/components/MarkdownPreview.jsx
+++ b/src/features/markdown/components/MarkdownPreview.jsx
@@ -42,7 +42,7 @@ const MarkdownPreview = ({ markdown }) => {
           wordBreak: 'break-word',
         },
       }}>
-      <Typography variant='h6' sx={{ mb: 1 }}>
+      <Typography variant='h6' sx={{ mb: 1, flexShrink: 0 }}>
         Preview
       </Typography>
       <div
@@ -51,6 +51,7 @@ const MarkdownPreview = ({ markdown }) => {
           fontFamily: 'inherit',
           fontSize: 16,
           flex: 1,
+          minHeight: 0,
           overflowY: 'auto',
           overflowX: 'hidden',
           paddingRight: '8px',


### PR DESCRIPTION
This pull request focuses on improving the scrollability and responsiveness of the markdown editor and preview containers in the `/shop` section. The changes ensure that both containers scroll independently, provide a better experience on mobile devices, and maintain a consistent design.

**Markdown Editor & Preview Improvements:**

* Switched the editor from MUI `TextField` to a native `textarea` for more reliable scroll behavior and finer control over styling (`src/features/markdown/components/MarkdownEditor.jsx`).
* Added `minHeight: 0` and `minWidth: 0` to flex containers and child elements to enable proper scrolling and fix flexbox overflow issues in both the editor and preview components (`src/features/markdown/components/MarkdownEditor.jsx`, `src/features/markdown/components/MarkdownPreview.jsx`). [[1]](diffhunk://#diff-c16deb4cf49c2e1b22752b8ea9bf77b9ac89b0fe2bca901091a02ae7d59a1059L14-R48) [[2]](diffhunk://#diff-adb58fe58b48726962596d6b7c1dc64f3f4b7eee74132d287127c343758cd167R54)
* Updated the background color of the editor container to match the outer container for a consistent look, and improved responsive layout for mobile devices (`src/features/markdown/components/MarkdownEditor.jsx`).

**Versioning & Documentation:**

* Bumped the app version to `1.1.3` in `package.json` to reflect these fixes.
* Added a changelog entry for version `1.1.3` summarizing the scrollability fixes and UI improvements (`CHANGELOG.md`).