### PR TITLE
Add local draft persistence and clear draft functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.3.0] - 2026-07-22
+
+### Added
+
+- Added automatic local draft persistence for markdown content, GitHub username, selected icons, and selected README sections.
+- Added a `Clear Draft` control in the markdown editor to reset the saved local draft and selected sections.
+
+### Changed
+
+- Updated the preview action button styling so the eye icon matches the bordered blue copy and insert action buttons.
+
 ## [1.2.0] - 2026-07-20
 
 ### Fixed
@@ -185,7 +196,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Home page and core feature files repeatedly reorganized for clarity.
 - Theme and UI consistency refactors for long-term maintainability.
 
-[Unreleased]: https://github.com/narainkarthikv/markdown-shop/compare/v1.1.2...HEAD
+[Unreleased]: https://github.com/narainkarthikv/markdown-shop/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/narainkarthikv/markdown-shop/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/narainkarthikv/markdown-shop/compare/v1.1.2...v1.2.0
 [1.1.2]: https://github.com/narainkarthikv/markdown-shop/releases/tag/v1.1.2
 [1.1.1]: https://github.com/narainkarthikv/markdown-shop/releases/tag/v1.1.1
 [1.0.3]: https://github.com/narainkarthikv/markdown-shop/releases/tag/v1.0.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-shop",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-shop",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "markdown-shop",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/src/components/ui/QuickActions.jsx
+++ b/src/components/ui/QuickActions.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box, IconButton, Tooltip, Button, ButtonGroup } from '@mui/material';
-import { useTheme, alpha } from '@mui/material/styles';
+import { Box, Tooltip, Button, ButtonGroup } from '@mui/material';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import AddIcon from '@mui/icons-material/Add';
@@ -9,8 +8,6 @@ import CheckIcon from '@mui/icons-material/Check';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 
 const QuickActions = ({ onPreview, onCopy, onUse, copied, isSelected }) => {
-  const theme = useTheme();
-
   return (
     <Box
       sx={{
@@ -20,18 +17,19 @@ const QuickActions = ({ onPreview, onCopy, onUse, copied, isSelected }) => {
         flexShrink: 0,
       }}>
       <Tooltip title='Preview template' arrow>
-        <IconButton
+        <Button
           onClick={onPreview}
           size='small'
+          variant='contained'
+          color='primary'
           sx={{
-            color: 'primary.main',
-            '&:hover': {
-              bgcolor: alpha(theme.palette.primary.main, 0.1),
-            },
+            minWidth: 'auto',
+            px: 1.5,
+            py: 0.75,
           }}
           aria-label='Preview template'>
           <VisibilityIcon fontSize='small' />
-        </IconButton>
+        </Button>
       </Tooltip>
 
       <ButtonGroup

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -17,6 +17,7 @@ export const STORAGE_KEYS = {
   THEME_MODE: 'markdown-shop-theme-mode',
   USER_PREFERENCES: 'markdown-shop-preferences',
   STORE: 'markdown-shop-store',
+  MARKDOWN_DRAFT: 'markdown-shop-markdown-draft',
 };
 
 /**

--- a/src/features/markdown/MarkdownLayout.jsx
+++ b/src/features/markdown/MarkdownLayout.jsx
@@ -5,19 +5,29 @@ import {
   TextField,
   Typography,
   InputAdornment,
+  Button,
 } from '@mui/material';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import MarkdownEditor from './components/MarkdownEditor';
 import MarkdownPreview from './components/MarkdownPreview';
 import { SectionSelector } from '@/components/SectionSelector';
+import { useShopStore } from '@/store/useShopStore';
 import useMarkdownStore from './store/markdownStore';
 import { useSectionPresets } from '@/hooks/useSectionPresets';
 
 const MarkdownLayout = () => {
-  const { markdown, setMarkdown, userName, setUserName } = useMarkdownStore();
+  const { markdown, setMarkdown, userName, setUserName, resetDraft } =
+    useMarkdownStore();
+  const clearSections = useShopStore((state) => state.clearSections);
   useSectionPresets();
 
   const handleMarkdownChange = (e) => {
     setMarkdown(e.target.value);
+  };
+
+  const handleClearDraft = () => {
+    resetDraft();
+    clearSections();
   };
 
   return (
@@ -63,9 +73,17 @@ const MarkdownLayout = () => {
             variant='body2'
             color='text.secondary'
             sx={{ maxWidth: 360 }}>
-            Update the username once and all GitHub components refresh
-            instantly.
+            Drafts save automatically in this browser, including markdown,
+            username, icons, and selected sections.
           </Typography>
+          <Button
+            variant='outlined'
+            color='error'
+            startIcon={<DeleteOutlineIcon />}
+            onClick={handleClearDraft}
+            sx={{ alignSelf: { xs: 'flex-start', md: 'center' } }}>
+            Clear Draft
+          </Button>
         </Stack>
       </Paper>
       <Box

--- a/src/features/markdown/store/markdownStore.js
+++ b/src/features/markdown/store/markdownStore.js
@@ -1,57 +1,82 @@
 import { create } from 'zustand';
-import { THEME_OPTIONS } from '@/utils/config/constants';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { STORAGE_KEYS, THEME_OPTIONS } from '@config/index';
 
-const useMarkdownStore = create((set) => ({
+const initialState = {
   markdown: '',
   userName: '',
   theme: THEME_OPTIONS.DEFAULT,
   iconNames: [],
-  setMarkdown: (markdown) => set({ markdown }),
-  setUserName: (userName) => set({ userName }),
-  setTheme: (theme) => set({ theme }),
-  insertSection: (content) =>
-    set((state) => ({
-      markdown: state.markdown ? `${state.markdown}\n\n${content}` : content,
-    })),
-  embedMarkdown: (content) =>
-    set((state) => ({
-      markdown: state.markdown ? `${state.markdown}\n${content}` : content,
-    })),
+};
 
-  embedIcon: (iconName) =>
-    set((state) => {
-      const newIconNames = [...state.iconNames, iconName];
-      const skilliconsUrl = `https://skillicons.dev/icons?i=${newIconNames.join(',')}`;
-      const iconMarkdown = `\n<!-- ICONS -->\n<img src="${skilliconsUrl}" />\n<!-- END ICONS -->\n`;
-      return {
-        iconNames: newIconNames,
-        markdown:
-          state.markdown.replace(
-            /<!-- ICONS -->\n.*\n<!-- END ICONS -->/s,
-            ''
-          ) + iconMarkdown,
-      };
+const useMarkdownStore = create(
+  persist(
+    (set) => ({
+      ...initialState,
+      setMarkdown: (markdown) => set({ markdown }),
+      setUserName: (userName) => set({ userName }),
+      setTheme: (theme) => set({ theme }),
+      insertSection: (content) =>
+        set((state) => ({
+          markdown: state.markdown
+            ? `${state.markdown}\n\n${content}`
+            : content,
+        })),
+      embedMarkdown: (content) =>
+        set((state) => ({
+          markdown: state.markdown ? `${state.markdown}\n${content}` : content,
+        })),
+
+      embedIcon: (iconName) =>
+        set((state) => {
+          const newIconNames = [...state.iconNames, iconName];
+          const skilliconsUrl = `https://skillicons.dev/icons?i=${newIconNames.join(',')}`;
+          const iconMarkdown = `\n<!-- ICONS -->\n<img src="${skilliconsUrl}" />\n<!-- END ICONS -->\n`;
+          return {
+            iconNames: newIconNames,
+            markdown:
+              state.markdown.replace(
+                /<!-- ICONS -->\n.*\n<!-- END ICONS -->/s,
+                ''
+              ) + iconMarkdown,
+          };
+        }),
+      removeIcon: (iconName) =>
+        set((state) => {
+          const newIconNames = state.iconNames.filter(
+            (name) => name !== iconName
+          );
+          const skilliconsUrl =
+            newIconNames.length > 0
+              ? `https://skillicons.dev/icons?i=${newIconNames.join(',')}`
+              : '';
+          const iconMarkdown = skilliconsUrl
+            ? `\n<!-- ICONS -->\n<img src="${skilliconsUrl}" />\n<!-- END ICONS -->\n`
+            : '';
+          return {
+            iconNames: newIconNames,
+            markdown:
+              state.markdown.replace(
+                /<!-- ICONS -->\n.*\n<!-- END ICONS -->/s,
+                ''
+              ) + iconMarkdown,
+          };
+        }),
+      resetMarkdown: () => set({ markdown: '' }),
+      resetDraft: () => set(initialState),
     }),
-  removeIcon: (iconName) =>
-    set((state) => {
-      const newIconNames = state.iconNames.filter((name) => name !== iconName);
-      const skilliconsUrl =
-        newIconNames.length > 0
-          ? `https://skillicons.dev/icons?i=${newIconNames.join(',')}`
-          : '';
-      const iconMarkdown = skilliconsUrl
-        ? `\n<!-- ICONS -->\n<img src="${skilliconsUrl}" />\n<!-- END ICONS -->\n`
-        : '';
-      return {
-        iconNames: newIconNames,
-        markdown:
-          state.markdown.replace(
-            /<!-- ICONS -->\n.*\n<!-- END ICONS -->/s,
-            ''
-          ) + iconMarkdown,
-      };
-    }),
-  resetMarkdown: () => set({ markdown: '' }),
-}));
+    {
+      name: STORAGE_KEYS.MARKDOWN_DRAFT,
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        markdown: state.markdown,
+        userName: state.userName,
+        theme: state.theme,
+        iconNames: state.iconNames,
+      }),
+      version: 1,
+    }
+  )
+);
 
 export default useMarkdownStore;

--- a/tests/e2e/github-integration.spec.ts
+++ b/tests/e2e/github-integration.spec.ts
@@ -15,7 +15,7 @@ test.describe('GitHub Username Integration', () => {
     await expect(usernameInput).toHaveValue(testUsername);
   });
 
-  test('resets GitHub username after route navigation', async ({ page }) => {
+  test('persists GitHub username after route navigation', async ({ page }) => {
     const testUsername = 'narainkarthikv';
 
     const usernameInput = getUsernameInput(page);
@@ -23,7 +23,7 @@ test.describe('GitHub Username Integration', () => {
     await usernameInput.fill(testUsername);
     await page.goto('/components');
     await page.goto('/shop');
-    await expect(getUsernameInput(page)).toHaveValue('');
+    await expect(getUsernameInput(page)).toHaveValue(testUsername);
   });
 
   test('clears username input', async ({ page }) => {

--- a/tests/e2e/markdown-editing.spec.ts
+++ b/tests/e2e/markdown-editing.spec.ts
@@ -52,13 +52,29 @@ test.describe('Markdown Editing', () => {
     await expect(markdownTextarea).toHaveValue('');
   });
 
-  test('resets markdown content after route navigation', async ({ page }) => {
+  test('persists markdown content after route navigation', async ({ page }) => {
     const testMarkdown = '# Persistent Content\n\nThis should persist.';
 
     const markdownTextarea = getMarkdownEditor(page);
     await markdownTextarea.fill(testMarkdown);
     await page.goto('/templates');
     await page.goto('/shop');
+    await expect(getMarkdownEditor(page)).toHaveValue(testMarkdown);
+  });
+
+  test('clears the saved local draft', async ({ page }) => {
+    const testMarkdown = '# Draft to clear';
+
+    const markdownTextarea = getMarkdownEditor(page);
+    await markdownTextarea.fill(testMarkdown);
+    await page
+      .getByPlaceholder(/octocat/i)
+      .first()
+      .fill('octocat');
+
+    await page.getByRole('button', { name: /clear draft/i }).click();
+
     await expect(getMarkdownEditor(page)).toHaveValue('');
+    await expect(page.getByPlaceholder(/octocat/i).first()).toHaveValue('');
   });
 });


### PR DESCRIPTION
## Merge develop into main

### Summary
Release version 1.3.0 with new draft persistence features and UI improvements.

### Changes

#### ✨ Added
- **Automatic Draft Persistence**: Markdown content, GitHub username, selected icons, and selected README sections now automatically save to browser's local storage
- **Clear Draft Control**: New "Clear Draft" button in the markdown editor to reset saved content and selected sections
- **Draft Storage Configuration**: Added `MARKDOWN_DRAFT` storage key for managing draft persistence

#### 🎨 UI/UX Improvements
- **Preview Button Styling**: Updated the eye icon preview action button to match the bordered blue style of copy and insert action buttons
- Changed preview action from `IconButton` to `Button` component for consistent styling

#### 🧪 Test Updates
- Updated `github-integration.spec.ts`: Tests now verify that GitHub username **persists** across route navigation (previously tested for reset)
- Updated `markdown-editing.spec.ts`: Tests now verify that markdown content **persists** across route navigation
- Added new test: `clears the saved local draft` - validates the Clear Draft button functionality

#### 📦 Version Bump
- Updated `package.json` and `package-lock.json` to version 1.3.0
- Updated `CHANGELOG.md` with new features and changes

### Files Modified
- `CHANGELOG.md` - Added v1.3.0 release notes
- `package.json` - Version bump to 1.3.0
- `package-lock.json` - Version synchronization
- `src/components/ui/QuickActions.jsx` - Preview button styling improvements
- `src/config/index.js` - Added MARKDOWN_DRAFT storage key
- `src/features/markdown/MarkdownLayout.jsx` - Added Clear Draft button and updated UI text
- `src/features/markdown/store/markdownStore.js` - Implemented localStorage persistence using zustand middleware
- `tests/e2e/github-integration.spec.ts` - Updated test expectations for persistence
- `tests/e2e/markdown-editing.spec.ts` - Updated test expectations for persistence + new clear draft test

### Type of Change
- ✨ New feature (automatic draft persistence)
- 🎨 UI improvement (button styling)
- 🐛 Enhancement (improved user experience)

### Testing
- All E2E tests have been updated to reflect new persistence behavior
- New test added for clear draft functionality
- Manual testing recommended for draft persistence across browser sessions